### PR TITLE
Update write-muse2log.R

### DIFF
--- a/code/write-muse2log.R
+++ b/code/write-muse2log.R
@@ -47,7 +47,7 @@ out <-
 
 						fp <-
 							fs::path_ext_remove(xml) |>
-							fs::path_rel(path = _, start = fs::path(home, main))
+							fs::path_rel(start = fs::path(home, main))
 
 
 						cat("\tWill write MUSE_ID =", fn, "\n")


### PR DESCRIPTION
Prior to this change, 'out' variable was NULL. Change was suggested by chat gpt and seems to work, unsure why.

Checked to ensure output contained all files with no duplicates.